### PR TITLE
Fix "[object Object]" bug and new function

### DIFF
--- a/TruStorage.es6.js
+++ b/TruStorage.es6.js
@@ -115,7 +115,7 @@ class TruStorage {
       // Generate objects if needed
       if (isSetMode && !(typeof currentLevel === 'object' && key in currentLevel)) {
         if (i !== strArrLn - 1) {
-          currentLevel[key] = {}
+          currentLevel[key] = i ? {} : '{}'
         } else {
           return null
         }

--- a/TruStorage.es6.js
+++ b/TruStorage.es6.js
@@ -21,6 +21,12 @@ class TruStorage {
     this.prefix = root ? (root.key + '.') : ''
   }
 
+  setDefault (str, value) {
+    if (this.getItem(str) == undefined) {
+      this.setItem(str, value)
+    }
+  }
+
   setItem (str, value, modifier) {
     const fetchPath = TruStorage._readLocalObj.call(this, str, value, modifier)
     return fetchPath
@@ -145,6 +151,7 @@ function getStorageObj (storageType) {
   })())
 
   return {
+    setDefault: storageObj.setDefault.bind(storageObj),
     setItem: storageObj.setItem.bind(storageObj),
     getItem: storageObj.getItem.bind(storageObj),
     removeItem: storageObj.removeItem.bind(storageObj),

--- a/truStorage.js
+++ b/truStorage.js
@@ -78,6 +78,12 @@ var TRUSTORAGE = function(storageType, root){
     return currentLevel;
   }
 
+  this.setDefault= function(str, value) {
+    if (this.getItem(str) == undefined) {
+      this.setItem(str, value)
+    }
+  };
+
   this.setItem= function(str, value, modifier){
     var fetchPath = _readLocalObj.call(this,str,value,modifier);
     return fetchPath;

--- a/truStorage.js
+++ b/truStorage.js
@@ -68,7 +68,7 @@ var TRUSTORAGE = function(storageType, root){
 
       //Generate objects if needed
       if( isSetMode && !(typeof currentLevel === "object" && key in currentLevel) ){
-        if(i !== strArrLn -1){currentLevel[key] = {};}
+        if(i !== strArrLn -1){currentLevel[key] = i ? {} : '{}';}
         else {return null;}
       }
       currentLevel = _makeFormat(currentLevel[key]);

--- a/truStorageWModifiers.js
+++ b/truStorageWModifiers.js
@@ -49,6 +49,11 @@ truStorage = {
 
 		return currentLevel;
 	},
+	setDefault : function(str, value){
+		if (this.getItem(str) == undefined){
+			this.setItem(str, value)
+		}
+	},
 	setItem : function(str, value, modifier){
 		var fetchPath = this.readLocalObj(str,value,modifier);
 		return fetchPath;

--- a/truStorageWModifiers.js
+++ b/truStorageWModifiers.js
@@ -38,7 +38,7 @@ truStorage = {
 
 			//Generate objects if needed
 			if( !(typeof currentLevel === "object" && key in currentLevel) ){
-				if(i !== strArrLn -1)currentLevel[key] = {};
+				if(i !== strArrLn -1)currentLevel[key] = i ? {} : '{}';
 				else currentLevel[key] = null;
 			}
 


### PR DESCRIPTION
If someone sets a value in a nested object without setting that object first the result is `"[object Object]"` (`Object.prototype.toString()`) instead of `"{}"` (`JSON.stringify({})`):
```
truStorage.getItem('test'); // undefined
truStorage.setItem('test.x', 1);
truStorage.getItem('test'); // "[object Object]"
```
After fix:
```
truStorage.getItem('test'); // undefined
truStorage.setItem('test.x', 1);
truStorage.getItem('test'); // {x: 1}
```

Also added new function `setDefault`:
```
truStorage.getItem('test.y'); // undefined
truStorage.setDefault('test.y', 2);
truStorage.getItem('test.y'); // 2
```
and
```
truStorage.getItem('test.y'); // 3, from a previous page visit let's say
truStorage.setDefault('test.y', 2);
truStorage.getItem('test.y'); // 3, it already had a value and was not overwritten
```
It sets the item only if it is not set already, previously had to do
```
if (truStorage.getItem('test.z') == undefined) {
    truStorage.setItem('test.z', zDefault);
}
```
now
```
truStorage.setDefault('test.z', zDefault);
```